### PR TITLE
Memory Leak on N-Quads Export

### DIFF
--- a/src/core/print/parse-printer.ts
+++ b/src/core/print/parse-printer.ts
@@ -1,7 +1,33 @@
 import { QuadSerializationConfiguration, serialize2quads } from '../../util/quads'
 import { xlm2jsonObject } from '../../r-bridge/lang-4.x/ast/parser/xml/internal'
-import { XmlParserConfig } from '../../r-bridge'
+import { XmlBasedJson, XmlParserConfig } from '../../r-bridge'
+
+function filterObject(obj: XmlBasedJson, keys: Set<string>): XmlBasedJson[] | XmlBasedJson {
+	if(typeof obj !== 'object') {
+		return obj
+	} else if(Array.isArray(obj)) {
+		return obj.map(e => filterObject(e as XmlBasedJson, keys) as XmlBasedJson)
+	}
+	if(Object.keys(obj).some(k => keys.has(k))) {
+		return Object.fromEntries(
+			Object.entries(obj)
+				.filter(([k]) => keys.has(k))
+				.map(([k, v]) => [k, filterObject(v as XmlBasedJson, keys)])
+		)
+	} else {
+		return Object.fromEntries(
+			Object.entries(obj)
+				.map(([k, v]) => [k, filterObject(v as XmlBasedJson, keys)])
+		)
+	}
+
+}
 
 export async function parseToQuads(code: string, config: QuadSerializationConfiguration, parseConfig: XmlParserConfig): Promise<string> {
-	return serialize2quads(await xlm2jsonObject(parseConfig, code), config)
+	const obj = await xlm2jsonObject(parseConfig, code)
+	// recursively filter so that if the object contains one of the keys 'a', 'b' or 'c', all other keys are ignored
+	return serialize2quads(
+		filterObject(obj, new Set([parseConfig.attributeName, parseConfig.childrenName, parseConfig.contentName])) as XmlBasedJson,
+		config
+	)
 }

--- a/src/util/quads.ts
+++ b/src/util/quads.ts
@@ -211,7 +211,10 @@ function processObjectEntry(key: string, value: unknown, obj: DataForQuad, quads
 	}
 }
 
-function serializeObject(obj: DataForQuad, quads: Quad[], config: Required<QuadSerializationConfiguration>): void {
+function serializeObject(obj: DataForQuad | undefined | null, quads: Quad[], config: Required<QuadSerializationConfiguration>): void {
+	if(obj === undefined || obj === null) {
+		return
+	}
 	if(obj instanceof Map) {
 		for(const [key, value] of obj.entries()) {
 			processObjectEntry('key-' + String(key), value, obj, quads, config)


### PR DESCRIPTION
It seems to be that the root issue (at least for the given file) was that the encoding caused the XML object conversion blew up beyond good and evil. I have added a filter, trying to be more robust (especially after #471).

@jofranky can you re-try your experiment with this state?