### PR TITLE
Remove flowR prefix from docker image versioning

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -36,7 +36,7 @@ jobs:
           VERSION="$(date '+%Y%m%d')"
           FLOWR_VERSION="$(docker run --rm flowr --version |  grep -oP 'flowR:\s*\K[^ ]+')"
           docker tag flowr "${TAG}":"date-$VERSION"
-          docker tag flowr "${TAG}":"flowr-$FLOWR_VERSION"
+          docker tag flowr "${TAG}":"$FLOWR_VERSION"
           docker tag flowr "${TAG}":latest
           docker images "$TAG"
           echo ${{ secrets.DH_PASSWD }} | docker login -u ${{ secrets.DH_NAME }} --password-stdin


### PR DESCRIPTION
To avoid the redundancy of specifying `flowr:flowr-x.y.z`. 