### PR TITLE
Refactor: Avoid async when interfacing with the R shell

### DIFF
--- a/src/r-bridge/shell-executor.ts
+++ b/src/r-bridge/shell-executor.ts
@@ -1,4 +1,4 @@
-import {DEFAULT_R_SHELL_OPTIONS, RShellOptions} from './shell'
+import {DEFAULT_R_SHELL_OPTIONS, RShellExecutionOptions} from './shell'
 import {deepMergeObject} from '../util/objects'
 import {spawnSync} from 'child_process'
 import {ts2r} from './lang-4.x'
@@ -9,14 +9,14 @@ import {log} from '../util/log'
 import fs from 'fs'
 
 export class RShellExecutor {
-	// TODO use a custom options class that doesn't have all the session stuff?
-	public readonly options:        Readonly<RShellOptions>
+
+	public readonly options:        Readonly<RShellExecutionOptions>
 	private readonly log:           Logger<ILogObj>
 	private readonly prerequisites: string[] = []
 
-	public constructor(options?: Partial<RShellOptions>) {
+	public constructor(options?: Partial<RShellExecutionOptions>) {
 		this.options = deepMergeObject(DEFAULT_R_SHELL_OPTIONS, options)
-		this.log = log.getSubLogger({ name: this.options.sessionName })
+		this.log = log.getSubLogger({ name: 'RShellExecutor' })
 	}
 
 	public continueOnError(): void {

--- a/src/r-bridge/shell-executor.ts
+++ b/src/r-bridge/shell-executor.ts
@@ -21,17 +21,19 @@ export class RShellExecutor {
 		this.log = log.getSubLogger({ name: 'RShellExecutor' })
 	}
 
-	public continueOnError(): void {
+	public continueOnError(): RShellExecutor {
 		this.log.info('continue in case of Errors')
 		this.prerequisites.push('options(error=function() {})')
+		return this
 	}
 
-	public injectLibPaths(...paths: string[]): void {
+	public injectLibPaths(...paths: string[]): RShellExecutor {
 		this.log.debug(`injecting lib paths ${JSON.stringify(paths)}`)
 		this.prerequisites.push(`.libPaths(c(.libPaths(), ${paths.map(ts2r).join(',')}))`)
+		return this
 	}
 
-	public tryToInjectHomeLibPath(): void {
+	public tryToInjectHomeLibPath(): RShellExecutor {
 		if(this.options.homeLibPath === undefined) {
 			this.log.debug('ensuring home lib path exists (automatic inject)')
 			this.prerequisites.push('if(!dir.exists(Sys.getenv("R_LIBS_USER"))) { dir.create(path=Sys.getenv("R_LIBS_USER"),showWarnings=FALSE,recursive=TRUE) }')
@@ -39,6 +41,7 @@ export class RShellExecutor {
 		} else {
 			this.injectLibPaths(this.options.homeLibPath)
 		}
+		return this
 	}
 
 	public usedRVersion(): SemVer | null{

--- a/src/r-bridge/shell-executor.ts
+++ b/src/r-bridge/shell-executor.ts
@@ -127,7 +127,7 @@ export class RShellExecutor {
 			env:      this.options.env,
 			cwd:      this.options.cwd,
 			encoding: 'utf8',
-			input:    this.prerequisites.concat(typeof commands == 'string' ? [commands] : commands).join(this.options.eol)
+			input:    [...this.prerequisites, commands].join(this.options.eol)
 		})
 		return (returnErr ? returns.stderr : returns.stdout).trim()
 	}

--- a/src/r-bridge/shell.ts
+++ b/src/r-bridge/shell.ts
@@ -61,7 +61,7 @@ export const DEFAULT_OUTPUT_COLLECTOR_CONFIGURATION: OutputCollectorConfiguratio
 	errorStopsWaiting:       true
 }
 
-export interface RShellSessionOptions extends MergeableRecord {
+export interface RShellExecutionOptions extends MergeableRecord {
 	/** The path to the R executable, can be only the executable if it is to be found on the PATH. */
 	readonly pathToRExecutable:  string
 	/** Command line options to use when starting the R session. */
@@ -72,12 +72,15 @@ export interface RShellSessionOptions extends MergeableRecord {
 	readonly eol:                string
 	/** The environment variables available in the R session. */
 	readonly env:                NodeJS.ProcessEnv
-	/** If set, the R session will be restarted if it exits due to an error */
-	readonly revive:             'never' | 'on-error' | 'always'
-	/** Called when the R session is restarted, this makes only sense if `revive` is not set to `'never'` */
-	readonly onRevive:           (code: number, signal: string | null) => void
 	/** The path to the library directory, use undefined to let R figure that out for itself */
 	readonly homeLibPath:        string | undefined
+}
+
+export interface RShellSessionOptions extends RShellExecutionOptions {
+	/** If set, the R session will be restarted if it exits due to an error */
+	readonly revive:   'never' | 'on-error' | 'always'
+	/** Called when the R session is restarted, this makes only sense if `revive` is not set to `'never'` */
+	readonly onRevive: (code: number, signal: string | null) => void
 }
 
 /**
@@ -88,16 +91,20 @@ export interface RShellOptions extends RShellSessionOptions {
 	readonly sessionName: string
 }
 
-export const DEFAULT_R_SHELL_OPTIONS: RShellOptions = {
-	sessionName:        'default',
+export const DEFAULT_R_SHELL_EXEC_OPTIONS: RShellExecutionOptions = {
 	pathToRExecutable:  getPlatform() === 'windows' ? 'R.exe' : 'R',
 	commandLineOptions: ['--vanilla', '--quiet', '--no-echo', '--no-save'],
 	cwd:                process.cwd(),
 	env:                process.env,
 	eol:                '\n',
 	homeLibPath:        getPlatform() === 'windows' ? undefined : '~/.r-libs',
-	revive:             'never',
-	onRevive:           () => { /* do nothing */ }
+} as const
+
+export const DEFAULT_R_SHELL_OPTIONS: RShellOptions = {
+	...DEFAULT_R_SHELL_EXEC_OPTIONS,
+	sessionName: 'default',
+	revive:      'never',
+	onRevive:    () => { /* do nothing */ }
 } as const
 
 /**

--- a/test/functionality/r-bridge/executor.ts
+++ b/test/functionality/r-bridge/executor.ts
@@ -69,4 +69,9 @@ describe('RShellExecutor', function() {
 			assert.isTrue(got.map(g => g[1]).includes('xmlparsedata'), `expected package xmlparsedata to be loaded, but got: ${JSON.stringify(got)}`)
 		})
 	})
+
+	it('token map', () => {
+		const executor = new RShellExecutor()
+		assert.doesNotThrow(() => executor.getTokenMap())
+	})
 })

--- a/test/functionality/r-bridge/executor.ts
+++ b/test/functionality/r-bridge/executor.ts
@@ -17,6 +17,7 @@ describe('RShellExecutor', function() {
 
 	it('ignore errors', () => {
 		const executor = new RShellExecutor()
+			.addPrerequisites('options(warn=-1); invisible(Sys.setlocale("LC_MESSAGES", \'en_GB.UTF-8\'))')
 
 		// check regular result when an error occurs
 		const error = executor.run('a', true)

--- a/test/functionality/r-bridge/executor.ts
+++ b/test/functionality/r-bridge/executor.ts
@@ -60,8 +60,7 @@ describe('RShellExecutor', function() {
 		})
 
 		it('ensure installed w/ autoload', () => {
-			const executor = new RShellExecutor()
-			executor.tryToInjectHomeLibPath()
+			const executor = new RShellExecutor().tryToInjectHomeLibPath()
 			executor.ensurePackageInstalled('xmlparsedata', true)
 			// prove if we have it as a loaded namespace (fresh shell!)
 			const got = parseCSV(executor.run('write.table(as.character(.packages()),sep=",", col.names=FALSE)').split('\n'))

--- a/test/functionality/r-bridge/r-bridge.spec.ts
+++ b/test/functionality/r-bridge/r-bridge.spec.ts
@@ -5,7 +5,7 @@ describe('R-Bridge', () => {
 
 	require('./lang/ast/model')
 	require('./sessions')
-	require('./sync')
+	require('./executor')
 	require('./retriever')
 
 	describe('Retrieve AST from R', () => {

--- a/test/functionality/r-bridge/r-bridge.spec.ts
+++ b/test/functionality/r-bridge/r-bridge.spec.ts
@@ -5,6 +5,7 @@ describe('R-Bridge', () => {
 
 	require('./lang/ast/model')
 	require('./sessions')
+	require('./sync')
 	require('./retriever')
 
 	describe('Retrieve AST from R', () => {

--- a/test/functionality/r-bridge/sync.ts
+++ b/test/functionality/r-bridge/sync.ts
@@ -5,7 +5,7 @@ import {RShellExecutor} from '../../../src/r-bridge/shell-executor'
 import fs from 'fs'
 import {testRequiresNetworkConnection} from '../_helper/network'
 
-describe('RShell sessions', function() {
+describe('RShellExecutor', function() {
 	const executor = new RShellExecutor()
 
 	it('R version', () => {

--- a/test/functionality/r-bridge/sync.ts
+++ b/test/functionality/r-bridge/sync.ts
@@ -4,6 +4,7 @@ import semver from 'semver/preload'
 import {RShellExecutor} from '../../../src/r-bridge/shell-executor'
 import fs from 'fs'
 import {testRequiresNetworkConnection} from '../_helper/network'
+import {isInstallTest} from '../main.spec'
 
 describe('RShellExecutor', function() {
 	const executor = new RShellExecutor()
@@ -29,7 +30,9 @@ describe('RShellExecutor', function() {
 		}).timeout('1m') // this is much slower than the async one since we start a new shell every time
 
 		it('ensure installed', async() => {
+			isInstallTest(this.ctx)
 			await testRequiresNetworkConnection(this.ctx)
+
 			for(const pkg of ['xmlparsedata', 'glue']) {
 				const result = executor.ensurePackageInstalled(pkg, true)
 				assert.equal(result.packageName, pkg)

--- a/test/functionality/r-bridge/sync.ts
+++ b/test/functionality/r-bridge/sync.ts
@@ -52,7 +52,6 @@ describe('RShellExecutor', function() {
 			for(const pkg of ['xmlparsedata', 'glue']) {
 				const result = executor.ensurePackageInstalled(pkg, false, true)
 				assert.equal(result.packageName, pkg)
-				assert.isTrue(executor.isPackageInstalled(pkg))
 
 				// clean up the temporary directory
 				if(result.libraryLocation !== undefined)

--- a/test/functionality/r-bridge/sync.ts
+++ b/test/functionality/r-bridge/sync.ts
@@ -5,24 +5,39 @@ import {RShellExecutor} from '../../../src/r-bridge/shell-executor'
 import fs from 'fs'
 import {testRequiresNetworkConnection} from '../_helper/network'
 import {isInstallTest} from '../main.spec'
+import {parseCSV} from '../../../src'
 
 describe('RShellExecutor', function() {
-	const executor = new RShellExecutor()
-
 	it('R version', () => {
-		const version = executor.usedRVersion()
+		const version = new RShellExecutor().usedRVersion()
 		guard(version !== null, 'we should be able to retrieve the version of R')
 		assert.isNotNull(semver.valid(version), `the version ${JSON.stringify(version)} should be a valid semver`)
 		assert.isTrue(semver.gt(version, '0.0.0'), `the version ${JSON.stringify(version)} should not be 0.0.0`)
 	})
 
+	it('ignore errors', () => {
+		const executor = new RShellExecutor()
+
+		// check regular result when an error occurs
+		const error = executor.run('a', true)
+		assert.match(error, /Error.*'a'/g)
+		assert.match(error, /halted/g)
+
+		// check continuing on error
+		executor.continueOnError()
+		const ignored = executor.run('a', true)
+		assert.match(ignored, /Error.*'a'/g)
+		assert.notMatch(ignored, /halted/g)
+	})
+
 	describe('install packages', function() {
 		it('retrieve all', () => {
-			const installed = executor.allInstalledPackages()
+			const installed = new RShellExecutor().allInstalledPackages()
 			assert.isTrue(installed.includes('base'), `base should be installed, but got: "${JSON.stringify(installed)}"`)
 		})
 
 		it('check installed', () => {
+			const executor = new RShellExecutor()
 			for(const nameOfInstalledPackage of executor.allInstalledPackages()) {
 				const isInstalled = executor.isPackageInstalled(nameOfInstalledPackage)
 				assert.isTrue(isInstalled, `package ${nameOfInstalledPackage} should be installed due to allInstalledPackages`)
@@ -33,8 +48,9 @@ describe('RShellExecutor', function() {
 			isInstallTest(this.ctx)
 			await testRequiresNetworkConnection(this.ctx)
 
+			const executor = new RShellExecutor()
 			for(const pkg of ['xmlparsedata', 'glue']) {
-				const result = executor.ensurePackageInstalled(pkg, true)
+				const result = executor.ensurePackageInstalled(pkg, false, true)
 				assert.equal(result.packageName, pkg)
 				assert.isTrue(executor.isPackageInstalled(pkg))
 
@@ -42,6 +58,16 @@ describe('RShellExecutor', function() {
 				if(result.libraryLocation !== undefined)
 					fs.rmSync(result.libraryLocation, { recursive: true, force: true })
 			}
+		})
+
+		it('ensure installed w/ autoload', () => {
+			const executor = new RShellExecutor()
+			executor.tryToInjectHomeLibPath()
+			executor.ensurePackageInstalled('xmlparsedata', true)
+			// prove if we have it as a loaded namespace (fresh shell!)
+			const got = parseCSV(executor.run('write.table(as.character(.packages()),sep=",", col.names=FALSE)').split('\n'))
+
+			assert.isTrue(got.map(g => g[1]).includes('xmlparsedata'), `expected package xmlparsedata to be loaded, but got: ${JSON.stringify(got)}`)
 		})
 	})
 })

--- a/test/functionality/r-bridge/sync.ts
+++ b/test/functionality/r-bridge/sync.ts
@@ -1,0 +1,14 @@
+import {guard} from '../../../src/util/assert'
+import {assert} from 'chai'
+import semver from 'semver/preload'
+import {RShellExecutor} from '../../../src/r-bridge/shell-executor'
+
+describe('RShell sessions', function() {
+	const executor = new RShellExecutor()
+	it('R version', () => {
+		const version = executor.usedRVersion()
+		guard(version !== null, 'we should be able to retrieve the version of R')
+		assert.isNotNull(semver.valid(version), `the version ${JSON.stringify(version)} should be a valid semver`)
+		assert.isTrue(semver.gt(version, '0.0.0'), `the version ${JSON.stringify(version)} should not be 0.0.0`)
+	})
+})

--- a/test/functionality/r-bridge/sync.ts
+++ b/test/functionality/r-bridge/sync.ts
@@ -2,13 +2,43 @@ import {guard} from '../../../src/util/assert'
 import {assert} from 'chai'
 import semver from 'semver/preload'
 import {RShellExecutor} from '../../../src/r-bridge/shell-executor'
+import fs from 'fs'
+import {testRequiresNetworkConnection} from '../_helper/network'
 
 describe('RShell sessions', function() {
 	const executor = new RShellExecutor()
+
 	it('R version', () => {
 		const version = executor.usedRVersion()
 		guard(version !== null, 'we should be able to retrieve the version of R')
 		assert.isNotNull(semver.valid(version), `the version ${JSON.stringify(version)} should be a valid semver`)
 		assert.isTrue(semver.gt(version, '0.0.0'), `the version ${JSON.stringify(version)} should not be 0.0.0`)
+	})
+
+	describe('install packages', function() {
+		it('retrieve all', () => {
+			const installed = executor.allInstalledPackages()
+			assert.isTrue(installed.includes('base'), `base should be installed, but got: "${JSON.stringify(installed)}"`)
+		})
+
+		it('check installed', () => {
+			for(const nameOfInstalledPackage of executor.allInstalledPackages()) {
+				const isInstalled = executor.isPackageInstalled(nameOfInstalledPackage)
+				assert.isTrue(isInstalled, `package ${nameOfInstalledPackage} should be installed due to allInstalledPackages`)
+			}
+		}).timeout('1m') // this is much slower than the async one since we start a new shell every time
+
+		it('ensure installed', async() => {
+			await testRequiresNetworkConnection(this.ctx)
+			for(const pkg of ['xmlparsedata', 'glue']) {
+				const result = executor.ensurePackageInstalled(pkg, true)
+				assert.equal(result.packageName, pkg)
+				assert.isTrue(executor.isPackageInstalled(pkg))
+
+				// clean up the temporary directory
+				if(result.libraryLocation !== undefined)
+					fs.rmSync(result.libraryLocation, { recursive: true, force: true })
+			}
+		})
 	})
 })


### PR DESCRIPTION
Also known as: add entirely synchronous `RShellExecutor` class