### PR TITLE
Migrate CI `setup-node`

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -18,7 +18,7 @@ runs:
       uses: actions/checkout@v4
 
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
 


### PR DESCRIPTION
Use `v4` of `setup-node` in the setup action (it was already being used in the release action)