### PR TITLE
Force Checked Index Access

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "outDir": "./dist/",
-    "strict": true
+    "strict": true,
+    "noUncheckedIndexedAccess": true
   },
   "lib": [ "esnext", "dom" ],
   "exclude": [


### PR DESCRIPTION
It turns out that this causes a ***lot*** of errors, so I was thinking we should potentially use a different option than `noUncheckedIndexedAccess`, since a lot of the situations that this causes a warning in seem pretty safe tbh