### PR TITLE
feat-fix: fix REPL parsing with inline scripts

### DIFF
--- a/src/cli/repl/core.ts
+++ b/src/cli/repl/core.ts
@@ -58,7 +58,7 @@ async function replProcessStatement(output: ReplOutput, statement: string, shell
  */
 export async function replProcessAnswer(output: ReplOutput, expr: string, shell: RShell): Promise<void> {
 
-	const statements = splitAtEscapeSensitive(expr, ';')
+	const statements = splitAtEscapeSensitive(expr, false, ';')
 
 	for(const statement of statements) {
 		await replProcessStatement(output, statement, shell)

--- a/src/util/args.ts
+++ b/src/util/args.ts
@@ -5,14 +5,18 @@
  */
 
 /**
- * This splits an input string on the given split string (e.g., ` `) but checks if the string is quoted or escaped.
+ * This splits an input string on the given split string (e.g., ` `), but checks if the string is quoted or escaped.
  *
- * Given an input string like `a "b c" d` with a space character as split this splits the arguments similar to common shell interpreters (i.e., `a`, `b c`, and `d`).
+ * Given an input string like `a "b c" d`, with a space character as split, and escapeQuote set to true,
+ * this splits the arguments similar to common shell interpreters (i.e., `a`, `b c`, and `d`).
+ * 
+ * When escapeQuote is set to false instead, we keep quotation marks in the result (i.e., `a`, `"b c"`, and `d`.).
  *
  * @param inputString - The string to split
- * @param split       - The **single** character to split on (can not be the backslash or quote)
+ * @param escapeQuote - Keep quotes in args
+ * @param split       - The **single** character to split on (can not be backslash or quote)
  */
-export function splitAtEscapeSensitive(inputString: string, split = ' '): string[] {
+export function splitAtEscapeSensitive(inputString: string, escapeQuote = true, split = ' '): string[] {
 	const args = []
 	let current = ''
 	let inQuotes = false
@@ -35,6 +39,9 @@ export function splitAtEscapeSensitive(inputString: string, split = ' '): string
 			current = ''
 		} else if(c === '"' || c === "'") {
 			inQuotes = !inQuotes
+			if(!escapeQuote) {
+				current += c
+			}
 		} else if(c === '\\') {
 			escaped = true
 		} else {

--- a/test/functionality/util/arguments-tests.ts
+++ b/test/functionality/util/arguments-tests.ts
@@ -2,13 +2,13 @@ import { splitAtEscapeSensitive } from '../../../src/util/args'
 import { assert } from 'chai'
 
 describe('Arguments', () => {
-	describe('splitArguments', () => {
-		const positive = (input: string, expected: string[], split = ' ') => {
-			it(`${JSON.stringify(input)}`, () => {
-				assert.deepEqual(splitAtEscapeSensitive(input, split), expected)
-			})
-		}
+	const positive = (input: string, expected: string[], escapeQuote = true, split = ' ') => {
+		it(`${JSON.stringify(input)}`, () => {
+			assert.deepEqual(splitAtEscapeSensitive(input, escapeQuote, split), expected)
+		})
+	}
 
+	describe('split arguments', () => {		
 		positive('', [])
 		positive('a', ['a'])
 		positive('a b', ['a', 'b'])
@@ -21,5 +21,17 @@ describe('Arguments', () => {
 		positive('a "b c" d "e f"', ['a', 'b c', 'd', 'e f'])
 		positive('a \\"b c" d "e f" g', ['a', '"b', 'c d e', 'f g'])
 		positive('a\\ b', ['a b'])
+		positive('-c "2@x" -r "x <- 3 * 4\n y <- x * 2', ['-c', '2@x', '-r', 'x <- 3 * 4\n y <- x * 2'])
+	})
+
+	describe('split statements', () => {
+		const positiveStatements = (input: string, expected: string[]) => positive(input, expected, false, ';')
+		positiveStatements(':help', [':help'])
+		positiveStatements(':help;:slicer', [':help', ':slicer'])
+		// Try out slicer examples
+		positiveStatements(':slicer -c "2@x" -r "x <- 3 * 4\n y <- x * 2"', [':slicer -c "2@x" -r "x <- 3 * 4\n y <- x * 2"'])
+		positiveStatements(':slicer -c "12@product" test/testfiles/example.R', [':slicer -c "12@product" test/testfiles/example.R'])
+		positiveStatements(':slicer --help; :slicer -i example.R --stats --criterion "8:3;3:1;12@product"', 
+			[':slicer --help', ' :slicer -i example.R --stats --criterion "8:3;3:1;12@product"'])
 	})
 })


### PR DESCRIPTION
Closes #618, i.e. REPL parsing of statements that have quotation marks

The first parsing step (split for statements) keeps quotation marks. 
The second parsing steps (split for arguments) keeps quoted items, i.e. inline R scripts, together:

```
R> :slicer -c "2@x" -r "x <- 3 * 4\n y <- x * 2"
> x <- 3 * 4
x * 2
R> 
```