### PR TITLE
doc: Explain how to run tests from IDEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "npm run license-compat -- --summary && eslint src/ test/",
     "license-compat": "license-checker --onlyAllow 'MIT;MIT OR X11;GPLv2;LGPL;GNUGPL;ISC;Apache-2.0;FreeBSD;BSD-2-Clause;clearbsd;ModifiedBSD;BSD-3-Clause;Python-2.0;Unlicense;WTFPL;CC-BY-4.0;CC-BY-3.0;CC0-1.0;0BSD'",
     "doc": "typedoc",
-    "test": "nyc --no-clean mocha --require ts-node/register --timeout 60000 \"test/**/*.spec.ts\"",
+    "test": "nyc --no-clean mocha",
     "performance-test": "func() { cd test/performance/ && bash run-all-suites.sh $1 $2; cd ../../; }; func",
     "test-full": "npm run test -- --test-installation"
   },
@@ -41,6 +41,11 @@
   ],
   "author": "Florian Sihler",
   "license": "ISC",
+  "mocha": {
+    "require": "ts-node/register",
+    "timeout": 60000,
+    "spec": "test/**/*.spec.ts"
+  },
   "nyc": {
     "all": true,
     "per-file": true,

--- a/wiki/Linting and Testing.md
+++ b/wiki/Linting and Testing.md
@@ -7,6 +7,8 @@ For the latest code-coverage information, see [codecov.io](https://codecov.io/gh
     - [Running Only Some Tests](#running-only-some-tests)
   - [Performance Tests](#performance-tests)
   - [Oh no, the tests are slow](#oh-no-the-tests-are-slow)
+  - [Testing Within Your IDE](#testing-within-your-ide)
+    - [Using Visual Studio Code](#using-visual-studio-code)
 - [CI Pipeline](#ci-pipeline)
 - [Linting](#linting)
   - [Oh no, the linter fails](#oh-no-the-linter-fails)
@@ -84,6 +86,23 @@ R&nbsp; may ask you if it should create a personal library, which you should con
 Now, the tests should run much faster!
 
 If, however, you have already installed the package, or the tests are still too slow for your taste, you may want to check out how to [run only some of the tests](#running-only-some-tests).
+
+### Testing Within Your IDE
+
+From your IDE of choice, you may also run all or some of the functionality tests that flowR provides.
+
+#### Using Visual Studio Code
+
+Using the Mocha Test Explorer extension, you may run all or some functionality tests from VS Code (or VSCodium). To do so:
+
+1. Install and enable the [Mocha Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-mocha-test-adapter).
+2. In your copy of the flowR repository, open the Testing menu. You should see all functionality tests available for execution, like this: 
+
+![Overview on all functionality tests in VS Code](img/testing-vs-code.png)
+
+3. To run the full test suite, press the Play button (▶️) above. To only run a single, or some of the tests, navigate to it, and press the Play button, too. You can cancel running tests by clicking on the Stop button (⏹️).
+   Successful tests are marked with a checkmark (✅), while failing tests are marked with a cross (❌).
+4. To debug a failing test, navigate to it, and then press the Debug (🪲) button. This will automatically open the Run and Debug menu of VS Code.
 
 ## CI Pipeline
 

--- a/wiki/Linting and Testing.md
+++ b/wiki/Linting and Testing.md
@@ -9,6 +9,7 @@ For the latest code-coverage information, see [codecov.io](https://codecov.io/gh
   - [Oh no, the tests are slow](#oh-no-the-tests-are-slow)
   - [Testing Within Your IDE](#testing-within-your-ide)
     - [Using Visual Studio Code](#using-visual-studio-code)
+    - [Using WebStorm](#using-webstorm)
 - [CI Pipeline](#ci-pipeline)
 - [Linting](#linting)
   - [Oh no, the linter fails](#oh-no-the-linter-fails)
@@ -89,11 +90,11 @@ If, however, you have already installed the package, or the tests are still too 
 
 ### Testing Within Your IDE
 
-From your IDE of choice, you may also run all or some of the functionality tests that flowR provides.
+From your IDE of choice, you can also run all or some of the functionality tests that flowR provides.
 
 #### Using Visual Studio Code
 
-Using the Mocha Test Explorer extension, you may run all or some functionality tests from VS Code (or VSCodium). To do so:
+With Visual Studio Code (or Codium), you also require the Mocha Test Explorer add-on. To run functionality tests, follow these steps:
 
 1. Install and enable the [Mocha Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-mocha-test-adapter).
 2. In your copy of the flowR repository, open the Testing menu. You should see all functionality tests available for execution, like this: 
@@ -103,6 +104,22 @@ Using the Mocha Test Explorer extension, you may run all or some functionality t
 3. To run the full test suite, press the Play button (▶️) above. To only run a single, or some of the tests, navigate to it, and press the Play button, too. You can cancel running tests by clicking on the Stop button (⏹️).
    Successful tests are marked with a checkmark (✅), while failing tests are marked with a cross (❌).
 4. To debug a failing test, navigate to it, and then press the Debug (🪲) button. This will automatically open the Run and Debug menu of VS Code.
+
+#### Using WebStorm
+
+With WebStorm, you can set up Run and Debug configurations from the IDE to run tests without additional add-ons.
+
+1. If you only want to run those tests from a single test file, navigate to that file in the Project view, and then right-click on it. Then select `Run (file)`, or `Debug (file)`.
+   You can also open the test file directly, to run a single test from it.
+2. If you want to run the whole test suite, you need to set-up a new Run/Debug configuration:
+   1. In the Run/Debug Configurations part of WebStorm, click the Drop-Down menu, and then `Edit Configurations`.
+   2. Click on `+` to add a new configuration, and then select `Mocha`.
+   3. Set the name of this new configuration, and select `File patterns` to run all specified functionality tests, like in this example:
+
+![A possible Run configuration for flowR's functionality tests in WebStorm](img/testing-config-webstorm.png)
+
+   1. Press `OK` to save the test run configuration.
+   Afterwards, you can run or debug the flowR functionality test suite from the Run/Debug configurations part, by clicking on the Play and Debug buttons (▶️/🪲), respectively.
 
 ## CI Pipeline
 

--- a/wiki/Linting and Testing.md
+++ b/wiki/Linting and Testing.md
@@ -101,8 +101,10 @@ With Visual Studio Code (or Codium), you also require the Mocha Test Explorer ad
 
 ![Overview on all functionality tests in VS Code](img/testing-vs-code.png)
 
-3. To run the full test suite, press the Play button (▶️) above. To only run a single, or some of the tests, navigate to it, and press the Play button, too. You can cancel running tests by clicking on the Stop button (⏹️).
-   Successful tests are marked with a checkmark (✅), while failing tests are marked with a cross (❌).
+3. To run the full test suite, press the Play button (▶️) above. 
+   - To only run a single, or some of the tests, navigate to it, and press the Play button, too. 
+   - You can cancel running tests by clicking on the Stop button (⏹️).
+   - Successful tests are marked with a checkmark (✅), while failing tests are marked with a cross (❌).
 4. To debug a failing test, navigate to it, and then press the Debug (🪲) button. This will automatically open the Run and Debug menu of VS Code.
 
 #### Using WebStorm
@@ -114,11 +116,11 @@ With WebStorm, you can set up Run and Debug configurations from the IDE to run t
 2. If you want to run the whole test suite, you need to set-up a new Run/Debug configuration:
    1. In the Run/Debug Configurations part of WebStorm, click the Drop-Down menu, and then `Edit Configurations`.
    2. Click on `+` to add a new configuration, and then select `Mocha`.
-   3. Set the name of this new configuration, and select `File patterns` to run all specified functionality tests, like in this example:
-
+   3. Set the name of this new configuration, and select `File patterns` to run all specified functionality tests, like in the example above.
 ![A possible Run configuration for flowR's functionality tests in WebStorm](img/testing-config-webstorm.png)
 
-   1. Press `OK` to save the test run configuration.
+   4. Press `OK` to save the test run configuration.
+   
    Afterwards, you can run or debug the flowR functionality test suite from the Run/Debug configurations part, by clicking on the Play and Debug buttons (▶️/🪲), respectively.
 
 ## CI Pipeline

--- a/wiki/img/testing-config-webstorm.png
+++ b/wiki/img/testing-config-webstorm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbdede146e00bd57db036b2ec2d3b3c98a25edd44b97b8876496db23308ed25a
+size 74188

--- a/wiki/img/testing-vs-code.png
+++ b/wiki/img/testing-vs-code.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56226ff560cb192737488aae6c0ce7d5290744d6c59ae03bb9ff24725b83cf1d
+size 56967


### PR DESCRIPTION
Changes:
- Wrote explanation in Wiki -> Linting and Testing.
- Illustrated with Pictures.
- Made Mocha config explicit in `package.json`, to allow easy setup.
- Tried for both VS Code and WebStorm.

Question:
- Should tests using the installer also run from IDEs?