### PR TITLE
Always Require Parenthesis with `new`

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,7 +300,8 @@
           ]
         }
       ],
-      "@typescript-eslint/consistent-type-imports": "error"
+      "@typescript-eslint/consistent-type-imports": "error",
+      "new-parens": "error"
     }
   },
   "release-it": {

--- a/src/benchmark/slicer.ts
+++ b/src/benchmark/slicer.ts
@@ -82,7 +82,7 @@ export interface BenchmarkSingleSliceStats extends MergeableRecord {
 export class BenchmarkSlicer {
 	/** Measures all data that is recorded *once* per slicer (complete setup up to the dataflow graph creation) */
 	private readonly commonMeasurements = new Measurements<CommonSlicerMeasurements>()
-	private readonly perSliceMeasurements = new Map<SlicingCriteria, PerSliceStats>
+	private readonly perSliceMeasurements = new Map<SlicingCriteria, PerSliceStats>()
 	private readonly shell: RShell
 	private stats:          SlicerStats | undefined
 	private loadedXml:      string | undefined

--- a/src/statistics/features/supported/assignments/post-process.ts
+++ b/src/statistics/features/supported/assignments/post-process.ts
@@ -52,7 +52,7 @@ function retrieveUsageCombinationCounts(collected: SummarizedAssignmentInfo<numb
 		return new Map()
 	}
 	const allCombinations = [...getUniqueCombinationsOfSize(ops, 1)]
-	const store = new Map<string, { uniqueProjects: Set<string>, uniqueFiles: Set<string> }>
+	const store = new Map<string, { uniqueProjects: Set<string>, uniqueFiles: Set<string> }>()
 	for(const combs of allCombinations) {
 		if(combs.length === 1) {
 			// we can just copy the information

--- a/src/statistics/output/ansi.ts
+++ b/src/statistics/output/ansi.ts
@@ -54,7 +54,7 @@ export const voidFormatter: OutputFormatter = new class implements OutputFormatt
 	public reset(): string {
 		return ''
 	}
-}
+}()
 
 /**
  * This does not work if the {@link setFormatter | formatter} is void. Tries to format the text with a bold font weight.

--- a/src/util/cfg/visitor.ts
+++ b/src/util/cfg/visitor.ts
@@ -73,7 +73,7 @@ class ControlFlowGraphExecutionTraceVisitor {
 	}
 
 	visit(cfg: ControlFlowInformation): void {
-		const visited = new Set<NodeId>
+		const visited = new Set<NodeId>()
 		for(const id of cfg.entryPoints) {
 			const node = cfg.graph.vertices().get(id)
 			guard(node !== undefined, `Node with id ${id} not present`)


### PR DESCRIPTION
added the rule and fixed resulting style inconsistencies