### PR TITLE
ESLint Stylistic checks formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,10 @@
       "devDependencies": {
         "@commitlint/cli": "^18.4.3",
         "@commitlint/config-angular": "^18.4.3",
+        "@stylistic/eslint-plugin": "^1.6.2",
+        "@stylistic/eslint-plugin-migrate": "^1.6.2",
+        "@stylistic/eslint-plugin-plus": "^1.6.2",
+        "@stylistic/eslint-plugin-ts": "^1.6.2",
         "@types/chai": "^4.3.11",
         "@types/chai-as-promised": "^7.1.8",
         "@types/command-line-args": "^5.2.3",
@@ -877,6 +881,12 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint-stylistic/metadata": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-stylistic/metadata/-/metadata-1.6.2.tgz",
+      "integrity": "sha512-yO3NWVYqFe0/BJpco1+QI3aSTWMhVkPcy1M01fAAeLuPxsKsP7HEeFnLQgrtKyPRO1TvxJqfbNInsyXXU7p+aA==",
+      "dev": true
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
@@ -1477,6 +1487,489 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.6.2.tgz",
+      "integrity": "sha512-EFnVcKOE5HTiMlVwisL9hHjz8a69yBbJRscWF/z+/vl6M4ew8NVrBlY8ea7KdV8QtyCY4Yapmsbg5ZDfhWlEgg==",
+      "dev": true,
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "1.6.2",
+        "@stylistic/eslint-plugin-jsx": "1.6.2",
+        "@stylistic/eslint-plugin-plus": "1.6.2",
+        "@stylistic/eslint-plugin-ts": "1.6.2",
+        "@types/eslint": "^8.56.2"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.6.2.tgz",
+      "integrity": "sha512-ndT6X2KgWGxv8101pdMOxL8pihlYIHcOv3ICd70cgaJ9exwkPn8hJj4YQwslxoAlre1TFHnXd/G1/hYXgDrjIA==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^8.56.2",
+        "acorn": "^8.11.3",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-jsx": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.6.2.tgz",
+      "integrity": "sha512-hbbouazSJbHD/fshBIOLh9JgtSphKNoTCfHLSNBjAkXLK+GR4i2jhEZZF9P0mtXrNuy2WWInmpq/g0pfWBmSBA==",
+      "dev": true,
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "^1.6.2",
+        "@types/eslint": "^8.56.2",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-jsx/node_modules/picomatch": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.1.tgz",
+      "integrity": "sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-migrate": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-migrate/-/eslint-plugin-migrate-1.6.2.tgz",
+      "integrity": "sha512-1TpyH6GZ+rJolOoxCBG5YlFX5sKqWM0z6nZLcyoOPFveNvo1uAzFOiDQXU6z30rugI5YDJM0NuUJ84EN6vqHUw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-stylistic/metadata": "1.6.2",
+        "@typescript-eslint/utils": "^6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.6.2.tgz",
+      "integrity": "sha512-EDMwa6gzKw4bXRqdIAUvZDfIgwotbjJs8o+vYE22chAYtVAnA0Pcq+cPx0Uk35t2gvJWb5OaLDjqA6oy1tD0jg==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^8.56.2",
+        "@typescript-eslint/utils": "^6.21.0"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.6.2.tgz",
+      "integrity": "sha512-FizV58em0OjO/xFHRIy/LJJVqzxCNmYC/xVtKDf8aGDRgZpLo+lkaBKfBrbMkAGzhBKbYj+iLEFI4WEl6aVZGQ==",
+      "dev": true,
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "1.6.2",
+        "@types/eslint": "^8.56.2",
+        "@typescript-eslint/utils": "^6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -1544,6 +2037,22 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "dev": true
+    },
+    "node_modules/@types/eslint": {
+      "version": "8.56.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.3.tgz",
+      "integrity": "sha512-PvSf1wfv2wJpVIFUMSb+i4PvqNYkB9Rkp9ZDO3oaWzq4SKhsQk4mrMBr3ZH06I0hKrVGLBacmgl8JM4WVjb9dg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
     "node_modules/@types/http-cache-semantics": {
@@ -1864,9 +2373,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@commitlint/cli": "^18.4.3",
         "@commitlint/config-angular": "^18.4.3",
         "@stylistic/eslint-plugin": "^1.6.2",
-        "@stylistic/eslint-plugin-migrate": "^1.6.2",
         "@stylistic/eslint-plugin-plus": "^1.6.2",
         "@stylistic/eslint-plugin-ts": "^1.6.2",
         "@types/chai": "^4.3.11",
@@ -881,12 +880,6 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint-stylistic/metadata": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@eslint-stylistic/metadata/-/metadata-1.6.2.tgz",
-      "integrity": "sha512-yO3NWVYqFe0/BJpco1+QI3aSTWMhVkPcy1M01fAAeLuPxsKsP7HEeFnLQgrtKyPRO1TvxJqfbNInsyXXU7p+aA==",
-      "dev": true
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
@@ -1553,143 +1546,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-migrate": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-migrate/-/eslint-plugin-migrate-1.6.2.tgz",
-      "integrity": "sha512-1TpyH6GZ+rJolOoxCBG5YlFX5sKqWM0z6nZLcyoOPFveNvo1uAzFOiDQXU6z30rugI5YDJM0NuUJ84EN6vqHUw==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-stylistic/metadata": "1.6.2",
-        "@typescript-eslint/utils": "^6.21.0"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
-      "dev": true,
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-migrate/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@stylistic/eslint-plugin-plus": {

--- a/package.json
+++ b/package.json
@@ -139,15 +139,15 @@
       "eslint-plugin-tsdoc",
       "check-file",
       "@stylistic",
-      "@stylistic/migrate"
+      "@stylistic/js",
+      "@stylistic/ts"
     ],
     "rules": {
-      "indent": "off",
-      "object-curly-spacing": [
+      "@stylistic/js/object-curly-spacing": [
         "error",
         "always"
       ],
-      "@typescript-eslint/indent": [
+      "@stylistic/js/indent": [
         "error",
         "tab",
         {
@@ -158,14 +158,14 @@
           "SwitchCase": 1
         }
       ],
-      "quotes": [
+      "@stylistic/js/quotes": [
         "error",
         "single",
         {
           "avoidEscape": true
         }
       ],
-      "no-mixed-spaces-and-tabs": [
+      "@stylistic/no-mixed-spaces-and-tabs": [
         "error",
         "smart-tabs"
       ],
@@ -189,21 +189,21 @@
           "assertionStyle": "as"
         }
       ],
-      "@typescript-eslint/key-spacing": [
+      "@stylistic/ts/key-spacing": [
         "error",
         {
           "align": "value"
         }
       ],
-      "semi": [
+      "@stylistic/js/semi": [
         "error",
         "never"
       ],
-      "space-before-function-paren": [
+      "@stylistic/js/space-before-function-paren": [
         "error",
         "never"
       ],
-      "keyword-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
       "check-file/filename-naming-convention": [
         "error",
         {
@@ -216,7 +216,7 @@
           "*.spec.{js,jsx,ts,tsx}": "test/**"
         }
       ],
-      "@typescript-eslint/keyword-spacing": [
+      "@stylistic/ts/keyword-spacing": [
         "error",
         {
           "before": true,
@@ -249,7 +249,7 @@
           }
         }
       ],
-      "@typescript-eslint/space-before-function-paren": [
+      "@stylistic/ts/space-before-function-paren": [
         "error",
         "never"
       ],
@@ -308,13 +308,11 @@
       ],
       "@typescript-eslint/consistent-type-imports": "error",
       "curly": "error",
-      "brace-style": [
+      "@stylistic/js/brace-style": [
         "error",
         "1tbs"
       ],
-      "new-parens": "error",
-      "@stylistic/migrate/migrate-js": "error",
-      "@stylistic/migrate/migrate-ts": "error"
+      "@stylistic/js/new-parens": "error"
     }
   },
   "release-it": {
@@ -355,7 +353,6 @@
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-angular": "^18.4.3",
     "@stylistic/eslint-plugin": "^1.6.2",
-    "@stylistic/eslint-plugin-migrate": "^1.6.2",
     "@stylistic/eslint-plugin-plus": "^1.6.2",
     "@stylistic/eslint-plugin-ts": "^1.6.2",
     "@types/chai": "^4.3.11",

--- a/package.json
+++ b/package.json
@@ -137,11 +137,16 @@
     "plugins": [
       "@typescript-eslint",
       "eslint-plugin-tsdoc",
-      "check-file"
+      "check-file",
+      "@stylistic",
+      "@stylistic/migrate"
     ],
     "rules": {
       "indent": "off",
-      "object-curly-spacing": ["error", "always"],
+      "object-curly-spacing": [
+        "error",
+        "always"
+      ],
       "@typescript-eslint/indent": [
         "error",
         "tab",
@@ -303,8 +308,13 @@
       ],
       "@typescript-eslint/consistent-type-imports": "error",
       "curly": "error",
-      "brace-style": ["error", "1tbs"],
-      "new-parens": "error"
+      "brace-style": [
+        "error",
+        "1tbs"
+      ],
+      "new-parens": "error",
+      "@stylistic/migrate/migrate-js": "error",
+      "@stylistic/migrate/migrate-ts": "error"
     }
   },
   "release-it": {
@@ -344,6 +354,10 @@
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-angular": "^18.4.3",
+    "@stylistic/eslint-plugin": "^1.6.2",
+    "@stylistic/eslint-plugin-migrate": "^1.6.2",
+    "@stylistic/eslint-plugin-plus": "^1.6.2",
+    "@stylistic/eslint-plugin-ts": "^1.6.2",
     "@types/chai": "^4.3.11",
     "@types/chai-as-promised": "^7.1.8",
     "@types/command-line-args": "^5.2.3",

--- a/src/r-bridge/lang-4.x/ast/parser/xml/internal/control/if-then-else.ts
+++ b/src/r-bridge/lang-4.x/ast/parser/xml/internal/control/if-then-else.ts
@@ -15,13 +15,13 @@ import { parseLog } from '../../../json/parser'
 export function tryNormalizeIfThenElse(
 	data: ParserData,
 	tokens: [
-		 ifToken:    NamedXmlBasedJson,
-		 leftParen:  NamedXmlBasedJson,
-		 condition:  NamedXmlBasedJson,
-		 rightParen: NamedXmlBasedJson,
-		 then:       NamedXmlBasedJson,
-		 elseToken:  NamedXmlBasedJson,
-		 elseBlock:  NamedXmlBasedJson
+		ifToken:    NamedXmlBasedJson,
+		leftParen:  NamedXmlBasedJson,
+		condition:  NamedXmlBasedJson,
+		rightParen: NamedXmlBasedJson,
+		then:       NamedXmlBasedJson,
+		elseToken:  NamedXmlBasedJson,
+		elseBlock:  NamedXmlBasedJson
 	]): RIfThenElse | undefined {
 	// we start by parsing a regular if-then structure
 	parseLog.trace('trying to parse if-then-else structure')

--- a/src/r-bridge/lang-4.x/ast/parser/xml/internal/control/if-then.ts
+++ b/src/r-bridge/lang-4.x/ast/parser/xml/internal/control/if-then.ts
@@ -14,11 +14,11 @@ import { parseLog } from '../../../json/parser'
 export function tryNormalizeIfThen(
 	data: ParserData,
 	tokens: [
-		 ifToken:    NamedXmlBasedJson,
-		 leftParen:  NamedXmlBasedJson,
-		 condition:  NamedXmlBasedJson,
-		 rightParen: NamedXmlBasedJson,
-		 then:       NamedXmlBasedJson
+		ifToken:    NamedXmlBasedJson,
+		leftParen:  NamedXmlBasedJson,
+		condition:  NamedXmlBasedJson,
+		rightParen: NamedXmlBasedJson,
+		then:       NamedXmlBasedJson
 	]): RIfThenElse | undefined {
 	parseLog.trace('trying to parse if-then structure')
 	if(tokens[0].name !== RawRType.If) {

--- a/test/functionality/_helper/provider.ts
+++ b/test/functionality/_helper/provider.ts
@@ -130,10 +130,10 @@ export const RAssignmentOpPool: { flavor: 'assignment', str: string }[] =
 
 export const RNonAssignmentBinaryOpPool: { label: 'arithmetic' | 'logical' | 'comparison' | 'model formula', pool: typeof RArithmeticBinaryOpPool | typeof RLogicalBinaryOpPool | typeof RComparisonBinaryOpPool | typeof RModelFormulaBinaryOpPool }[] =
 	[
-	    { label: 'arithmetic', pool: RArithmeticBinaryOpPool },
-	    { label: 'logical',    pool: RLogicalBinaryOpPool },
-	    { label: 'comparison', pool: RComparisonBinaryOpPool },
-	    { label: 'model formula', pool: RModelFormulaBinaryOpPool }
+		{ label: 'arithmetic', pool: RArithmeticBinaryOpPool },
+		{ label: 'logical',    pool: RLogicalBinaryOpPool },
+		{ label: 'comparison', pool: RComparisonBinaryOpPool },
+		{ label: 'model formula', pool: RModelFormulaBinaryOpPool }
 	]
 
 export const RArithmeticUnaryOpPool: { flavor: 'arithmetic', str: string }[] =

--- a/test/functionality/_helper/shell.ts
+++ b/test/functionality/_helper/shell.ts
@@ -69,14 +69,14 @@ function removeInformation<T extends Record<string, unknown>>(obj: T, includeTok
 function assertAstEqualIgnoreSourceInformation<Info>(ast: RNode<Info>, expected: RNode<Info>, includeTokens: boolean, message?: () => string): void {
 	const astCopy = removeInformation(ast, includeTokens)
 	const expectedCopy = removeInformation(expected, includeTokens)
-	 try {
-		 assert.deepStrictEqual(astCopy, expectedCopy)
-	 } catch(e) {
+	try {
+		assert.deepStrictEqual(astCopy, expectedCopy)
+	} catch(e) {
 		if(message) {
 			console.error(message())
 		}
 		throw e
-	 }
+	}
 }
 
 export const retrieveNormalizedAst = async(shell: RShell, input: `file://${string}` | string, hooks?: DeepPartial<XmlParserHooks>): Promise<RNodeWithParent> => {

--- a/test/functionality/util/control-flow-graph-tests.ts
+++ b/test/functionality/util/control-flow-graph-tests.ts
@@ -16,8 +16,8 @@ import { defaultQuadIdGenerator } from '../../../src/util/quads'
 import { cfgToMermaidUrl } from '../../../src/util/mermaid'
 
 describe('Control Flow Graph', withShell(shell => {
-	 function assertCfg(code: string, partialExpected: Partial<ControlFlowInformation>) {
-		 // shallow copy is important to avoid killing the CFG :c
+	function assertCfg(code: string, partialExpected: Partial<ControlFlowInformation>) {
+		// shallow copy is important to avoid killing the CFG :c
 		const expected: ControlFlowInformation = { ...emptyControlFlowInformation(), ...partialExpected }
 		return it(code, async()=> {
 			const result = await new SteppingSlicer({
@@ -43,9 +43,9 @@ describe('Control Flow Graph', withShell(shell => {
 	}
 
 	assertCfg('if(TRUE) 1', {
-	   entryPoints: [ '3' ],
-		 exitPoints:  [ '3-exit' ],
-		 graph:       new ControlFlowGraph()
+		entryPoints: [ '3' ],
+		exitPoints:  [ '3-exit' ],
+		graph:       new ControlFlowGraph()
 			.addVertex({ id: '0', name: RType.Logical, type: CfgVertexType.Expression })
 			.addVertex({ id: '1', name: RType.Number, type: CfgVertexType.Expression })
 			.addVertex({ id: '3', name: RType.IfThenElse, type: CfgVertexType.Statement })

--- a/test/functionality/util/set-operations-tests.ts
+++ b/test/functionality/util/set-operations-tests.ts
@@ -4,7 +4,7 @@ import { jsonReplacer } from '../../../src/util/json'
 import type { Test } from 'mocha'
 
 describe('Set (operations)', () => {
-	 describe('setEquals', () => {
+	describe('setEquals', () => {
 		function test<T>(name: string, should: boolean, a: Set<T>, b: Set<T>): Test {
 			return it(name, () =>
 				assert.equal(setEquals(a, b), should, JSON.stringify(a, jsonReplacer) + ' ' + JSON.stringify(b, jsonReplacer)
@@ -16,7 +16,7 @@ describe('Set (operations)', () => {
 		test('multiple element sets', true, new Set([1, 2, 3]), new Set([1, 2, 3]))
 		test('independent order', true, new Set([1, 2, 3]), new Set([3, 1, 2]))
 
-		 test('different size', false, new Set([1, 2, 3]), new Set([1, 2]))
-		 test('different elements', false, new Set([1, 2, 3]), new Set([1, 2, 4]))
-	 })
+		test('different size', false, new Set([1, 2, 3]), new Set([1, 2]))
+		test('different elements', false, new Set([1, 2, 3]), new Set([1, 2, 4]))
+	})
 })

--- a/wiki/Linting and Testing.md
+++ b/wiki/Linting and Testing.md
@@ -164,7 +164,9 @@ npm run lint-local -- --fix
 
 ### Oh no, the linter fails
 
-By now, the rules should be rather stable and so, if the linter fails it is usually best if you (if necessary) read the respective [eslint](https://eslint.org/docs/latest/rules) description and fix the respective problem.
+By now, the rules should be rather stable and so, if the linter fails it is usually best if you (if necessary) read the respective description and fix the respective problem.
+Rules in this project cover general JavaScript issues [using regular ESLint](https://eslint.org/docs/latest/rules), TypeScript-specific issues [using typescript-eslint](https://typescript-eslint.io/rules/), and code formatting [with ESLint Stylistic](https://eslint.style/packages/default#rules).
+
 However, in case you think that the linter is wrong, please do not hesitate to open a [new issue](https://github.com/Code-Inspect/flowr/issues/new/choose).
 
 ### License Checker


### PR DESCRIPTION
Closes #677.
- [x] Added ESLint Stylistic packages (for JavaScript, TypeScript, and additional rules).
- [x] Migrated deprecated formatting rules to Stylistic (i.e. changed their prefixes).
- [x] Fixed inconsistent formatting of some source/test files.
- [x] Wiki page points to specific ESLint + Plugin rule sets. 