### PR TITLE
Ensure low logging level on npm by default

### DIFF
--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -54,6 +54,9 @@ export const enum LogLevel {
 
 function getActiveLog(): FlowrLogger {
 	return new FlowrLogger({
+		// set the default minimum level as Warn, and let all apps
+		// (like the REPL) update it to whatever they want it to be
+		minLevel:        LogLevel.Warn,
 		type:            'pretty',
 		name:            'main',
 		stylePrettyLogs: true,


### PR DESCRIPTION
All exisiting extension points, like the repl, the slicer and the tests, automatically set their log level to their desired level already, so this change will only have an effect on the npm package.