### PR TITLE
CI changes

### DIFF
--- a/.github/workflows/check-broken-links.yaml
+++ b/.github/workflows/check-broken-links.yaml
@@ -22,13 +22,9 @@ jobs:
           lfs: true
 
       - name: Check the README for broken links
-        uses: Wandalen/wretry.action@v1.4.10
+        uses: becheran/mlc@v0.16.3
         with:
-          action: becheran/mlc@v0.16.3
-          with: |
-            args: README.md
-          attempt_limit: 3
-          attempt_delay: 2000
+          args: README.md
 
       - name: Publish the Wiki
         uses: Andrew-Chen-Wang/github-wiki-action@v4
@@ -39,11 +35,7 @@ jobs:
           token: ${{ secrets.GH_DEPLOY_WIKI }}
 
       - name: Check the Wiki pages for broken links
-        uses: Wandalen/wretry.action@v1.4.10
+        uses: becheran/mlc@v0.16.3
         if: ${{ always() && !failure() }}
         with:
-          action: becheran/mlc@v0.16.3
-          with: |
-            args: wiki/
-          attempt_limit: 3
-          attempt_delay: 2000
+          args: wiki/

--- a/.github/workflows/check-broken-links.yaml
+++ b/.github/workflows/check-broken-links.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Check the README for broken links
         uses: Wandalen/wretry.action@v1.4.10
         with:
-          action: becheran/mlc@v0.16.2
+          action: becheran/mlc@v0.16.3
           with: |
             args: README.md
           attempt_limit: 3
@@ -42,7 +42,7 @@ jobs:
         uses: Wandalen/wretry.action@v1.4.10
         if: ${{ always() && !failure() }}
         with:
-          action: becheran/mlc@v0.16.2
+          action: becheran/mlc@v0.16.3
           with: |
             args: wiki/
           attempt_limit: 3

--- a/.github/workflows/check-broken-links.yaml
+++ b/.github/workflows/check-broken-links.yaml
@@ -22,7 +22,7 @@ jobs:
           lfs: true
 
       - name: Check the README for broken links
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: Wandalen/wretry.action@v1.4.10
         with:
           action: becheran/mlc@v0.16.2
           with: |
@@ -39,7 +39,7 @@ jobs:
           token: ${{ secrets.GH_DEPLOY_WIKI }}
 
       - name: Check the Wiki pages for broken links
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: Wandalen/wretry.action@v1.4.10
         if: ${{ always() && !failure() }}
         with:
           action: becheran/mlc@v0.16.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,7 +68,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -77,6 +77,6 @@ jobs:
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,10 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+    # PRs for docs need not concern themselves with _code quality_.
+    paths:
+    - 'src/**'
+    - 'test/**'
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
   schedule:
@@ -28,8 +32,8 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    runs-on: ${'ubuntu-latest'}
+    timeout-minutes: ${{ 360 }}
     permissions:
       actions: read
       contents: read
@@ -71,10 +75,6 @@ jobs:
 
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/performance-test.yaml
+++ b/.github/workflows/performance-test.yaml
@@ -35,7 +35,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: "⬇️ Get benchmark Artifacts (artificial)"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: benchmark-results-artificial
           path: benchmark-ai/
@@ -66,7 +66,7 @@ jobs:
           auto-push: false
 
       - name: "⬇️ Get benchmark Artifacts (social-science)"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: benchmark-results-social-science
           path: benchmark-ss/

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -12,6 +12,11 @@ name: "QA"
   pull_request:
     types: [ opened, synchronize ]
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'scripts/**'
   workflow_dispatch:
     inputs:
       force-full:

--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Coverage Reports to Codecov
         if: ${{ inputs.coverage }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload Benchmark Results
         if: ${{ inputs.benchmark != '' }}
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         with:
             name: benchmark-results-${{ inputs.benchmark }}
             path: test/performance/results/


### PR DESCRIPTION
Closes #683:

- [x] CodeQL checks on Pull Requests only run when source or test files are changed.
- [x] QA pipelines for Pull Requests also only run when source files are changed.
- [x] Also updated CodeQL, download/upload, retry, and CodeCov actions to their newest versions that use Node 20.
- [x] Fix Broken Link detection (?)