### PR TITLE
feat-fix: improve usedRVersion to return after a reasonable timeout

### DIFF
--- a/src/r-bridge/shell.ts
+++ b/src/r-bridge/shell.ts
@@ -58,8 +58,7 @@ export const DEFAULT_OUTPUT_COLLECTOR_CONFIGURATION: OutputCollectorConfiguratio
 	postamble: `🐧${'-'.repeat(5)}🐧`,
 	timeout:   {
 		ms:             750_000,
-		resetOnNewData: true,
-		reject:         true
+		resetOnNewData: true
 	},
 	keepPostamble:           false,
 	automaticallyTrimOutput: true,

--- a/test/functionality/r-bridge/sessions.ts
+++ b/test/functionality/r-bridge/sessions.ts
@@ -42,8 +42,7 @@ describe('RShell sessions', function() {
 			shell.sendCommandWithOutput('Sys.sleep(42)', {
 				timeout: {
 					ms:             1,
-					resetOnNewData: false,
-					reject:         true
+					resetOnNewData: false
 				}
 			})
 		)

--- a/test/functionality/r-bridge/sessions.ts
+++ b/test/functionality/r-bridge/sessions.ts
@@ -42,7 +42,8 @@ describe('RShell sessions', function() {
 			shell.sendCommandWithOutput('Sys.sleep(42)', {
 				timeout: {
 					ms:             1,
-					resetOnNewData: false
+					resetOnNewData: false,
+					reject:         true
 				}
 			})
 		)


### PR DESCRIPTION
This improvement/fix also includes an additional property for `CollectorTimeout` that allows skipping the rejection when the timeout is reached.